### PR TITLE
feat(cp-stars-frontend): change release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,8 @@ jobs:
         run: npm run build
 
       - name: "Package app"
-        run: tar -zcvf build.tar.gz build/
+        run: |
+          tar -zcvf build.tar.gz -C build .
 
       - name: "Upload artifact"
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
* build folder is placed directly into archive file, not in another folder inside of archive file (build is not sub-folder)